### PR TITLE
投稿を削除したログを表示させる実装

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -65,6 +65,11 @@ function handleDelete(req, res) {
         Post.findByPk(id).then((post) => {
           if (req.user === post.postedBy) {
             post.destroy().then(() => {
+              console.info(
+                `削除されました: user: ${req.user}, ` +
+                `remoteAddress: ${req.connection.remoteAddress}, ` +
+                `userAgent: ${req.headers['user-agent']} `
+              );
               handleRedirectPosts(req, res);
             });
           }


### PR DESCRIPTION
最初は　`handleRedirectPosts(req, res);`　以降に削除ログを表示させるコードを記述していた。
回答例にならって　`post.destroy().then(() => {`　以降に記述した。

両方のケースでログの表示に差異がないことを確認した。
が、リダイレクトしてページを離れる前にログを表示させるほうが自然と思った。